### PR TITLE
Support node 0 12 x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "int64-native",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "A simple uint64_t wrapper for JavaScript",
   "keywords": [
     "types",

--- a/src/Int64.cc
+++ b/src/Int64.cc
@@ -18,75 +18,78 @@ using namespace v8;
 Persistent<Function> Int64::constructor;
 
 void Int64::Init(Handle<Object> exports) {
-  Local<FunctionTemplate> tpl = FunctionTemplate::New(New);
-  tpl->SetClassName(String::NewSymbol("Int64"));
+  Isolate* isolate = Isolate::GetCurrent();
+
+  Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
+
+  tpl->SetClassName(String::NewFromUtf8(isolate, "Int64"));
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("toNumber"),
-    FunctionTemplate::New(ToNumber)->GetFunction()
+    String::NewFromUtf8(isolate, "toNumber"),
+    FunctionTemplate::New(isolate, ToNumber)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("valueOf"),
-    FunctionTemplate::New(ValueOf)->GetFunction()
+    String::NewFromUtf8(isolate, "valueOf"),
+    FunctionTemplate::New(isolate, ValueOf)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("toString"),
-    FunctionTemplate::New(ToString)->GetFunction()
+    String::NewFromUtf8(isolate, "toString"),
+    FunctionTemplate::New(isolate, ToString)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("toUnsignedDecimalString"),
-    FunctionTemplate::New(ToUnsignedDecimalString)->GetFunction()
+    String::NewFromUtf8(isolate, "toUnsignedDecimalString"),
+    FunctionTemplate::New(isolate, ToUnsignedDecimalString)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("toSignedDecimalString"),
-    FunctionTemplate::New(ToSignedDecimalString)->GetFunction()
+    String::NewFromUtf8(isolate, "toSignedDecimalString"),
+    FunctionTemplate::New(isolate, ToSignedDecimalString)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("equals"),
-    FunctionTemplate::New(Equals)->GetFunction()
+    String::NewFromUtf8(isolate, "equals"),
+    FunctionTemplate::New(isolate, Equals)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("compare"),
-    FunctionTemplate::New(Compare)->GetFunction()
+    String::NewFromUtf8(isolate, "compare"),
+    FunctionTemplate::New(isolate, Compare)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("high32"),
-    FunctionTemplate::New(High32)->GetFunction()
+    String::NewFromUtf8(isolate, "high32"),
+    FunctionTemplate::New(isolate, High32)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("low32"),
-    FunctionTemplate::New(Low32)->GetFunction()
+    String::NewFromUtf8(isolate, "low32"),
+    FunctionTemplate::New(isolate, Low32)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("shiftLeft"),
-    FunctionTemplate::New(ShiftLeft)->GetFunction()
+    String::NewFromUtf8(isolate, "shiftLeft"),
+    FunctionTemplate::New(isolate, ShiftLeft)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("shiftRight"),
-    FunctionTemplate::New(ShiftRight)->GetFunction()
+    String::NewFromUtf8(isolate, "shiftRight"),
+    FunctionTemplate::New(isolate, ShiftRight)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("and"),
-    FunctionTemplate::New(And)->GetFunction()
+    String::NewFromUtf8(isolate, "and"),
+    FunctionTemplate::New(isolate, And)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("or"),
-    FunctionTemplate::New(Or)->GetFunction()
+    String::NewFromUtf8(isolate, "or"),
+    FunctionTemplate::New(isolate, Or)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("xor"),
-    FunctionTemplate::New(Xor)->GetFunction()
+    String::NewFromUtf8(isolate, "xor"),
+    FunctionTemplate::New(isolate, Xor)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("add"),
-    FunctionTemplate::New(Add)->GetFunction()
+    String::NewFromUtf8(isolate, "add"),
+    FunctionTemplate::New(isolate, Add)->GetFunction()
   );
   tpl->PrototypeTemplate()->Set(
-    String::NewSymbol("sub"),
-    FunctionTemplate::New(Sub)->GetFunction()
+    String::NewFromUtf8(isolate, "sub"),
+    FunctionTemplate::New(isolate, Sub)->GetFunction()
   );
-  constructor = Persistent<Function>::New(tpl->GetFunction());
-  exports->Set(String::NewSymbol("Int64"), constructor);
+  constructor.Reset(isolate, tpl->GetFunction());
+  exports->Set(String::NewFromUtf8(isolate, "Int64"), tpl->GetFunction());
 }
 
 Int64::Int64() {
@@ -119,8 +122,9 @@ Int64::Int64(const Local<String>& s) {
 
 Int64::~Int64() {}
 
-Handle<Value> Int64::New(const Arguments& args) {
-  HandleScope scope;
+void Int64::New(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   Int64* obj = NULL;
   if (args.Length() == 0) {
     obj = new Int64();
@@ -136,79 +140,87 @@ Handle<Value> Int64::New(const Arguments& args) {
     }
   }
   if (obj == NULL) {
-    ThrowException(Exception::TypeError(String::New("Wrong arguments")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Wrong arguments")));
   }
   obj->Wrap(args.This());
-  return args.This();
+  args.GetReturnValue().Set(args.This());
 }
 
-Handle<Value> Int64::ToNumber(const Arguments& args) {
-  HandleScope scope;
+void Int64::ToNumber(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
-  if (obj->mValue >= 1ull << 53) {
-    return scope.Close(Number::New(numeric_limits<double>::infinity()));
+
+  if (obj->mValue >= (1ull << 53)) {
+    args.GetReturnValue().Set(numeric_limits<double>::infinity());
   }
-  double value = static_cast<double>(obj->mValue);
-  return scope.Close(Number::New(value));
+  else {
+    args.GetReturnValue().Set(static_cast<double>(obj->mValue));
+  }
 }
 
-Handle<Value> Int64::ValueOf(const Arguments& args) {
+void Int64::ValueOf(const FunctionCallbackInfo<Value>& args) {
   return ToNumber(args);
 }
 
-Handle<Value> Int64::ToString(const Arguments& args) {
-  HandleScope scope;
+void Int64::ToString(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   
   std::ostringstream o;
   o << "0x" << hex << setfill('0') << setw(16) << obj->mValue;
-  return scope.Close(String::New(o.str().c_str()));
+  args.GetReturnValue().Set(String::NewFromUtf8(isolate, o.str().c_str()));
 }
 
-Handle<Value> Int64::ToUnsignedDecimalString(const Arguments& args) {
-  HandleScope scope;
+void Int64::ToUnsignedDecimalString(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
 
   std::ostringstream o;
   o << obj->mValue;
-  return scope.Close(String::New(o.str().c_str()));
+  args.GetReturnValue().Set(String::NewFromUtf8(isolate, o.str().c_str()));
 }
 
-Handle<Value> Int64::ToSignedDecimalString(const Arguments& args) {
-  HandleScope scope;
+void Int64::ToSignedDecimalString(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
 
   std::ostringstream o;
   o << (static_cast<int64_t>(obj->mValue));
-  return scope.Close(String::New(o.str().c_str()));
+  args.GetReturnValue().Set(String::NewFromUtf8(isolate, o.str().c_str()));
 }
 
-Handle<Value> Int64::Equals(const Arguments& args) {
-  HandleScope scope;
+void Int64::Equals(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   if (args.Length() < 1) {
-    ThrowException(Exception::TypeError(String::New("Argument required")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Argument required")));
+    args.GetReturnValue().SetUndefined();
   }
   if (!args[0]->IsObject()) {
-    ThrowException(Exception::TypeError(String::New("Object expected")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Object expected")));
+    args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   Int64* otherObj = ObjectWrap::Unwrap<Int64>(args[0]->ToObject());
   bool isEqual = obj->mValue == otherObj->mValue;
-  return scope.Close(Boolean::New(isEqual));
+  args.GetReturnValue().Set(isEqual);
 }
 
-Handle<Value> Int64::Compare(const Arguments& args) {
-  HandleScope scope;
+void Int64::Compare(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   if (args.Length() < 1) {
-    ThrowException(Exception::TypeError(String::New("Argument required")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Argument required")));
+    args.GetReturnValue().SetUndefined();
   }
   if (!args[0]->IsObject()) {
-    ThrowException(Exception::TypeError(String::New("Object expected")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Object expected")));
+    args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   Int64* otherObj = ObjectWrap::Unwrap<Int64>(args[0]->ToObject());
@@ -218,70 +230,83 @@ Handle<Value> Int64::Compare(const Arguments& args) {
   } else if (obj->mValue > otherObj->mValue) {
     cmp = 1;
   }
-  return scope.Close(Int32::New(cmp));
+  args.GetReturnValue().Set(cmp);
 }
 
-Handle<Value> Int64::High32(const Arguments& args) {
-  HandleScope scope;
+void Int64::High32(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   uint32_t highBits = static_cast<uint32_t>(obj->mValue >> 32);
-  return scope.Close(Int32::NewFromUnsigned(highBits));
+  args.GetReturnValue().Set(highBits);
 }
 
-Handle<Value> Int64::Low32(const Arguments& args) {
-  HandleScope scope;
+void Int64::Low32(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   uint32_t lowBits = static_cast<uint32_t>(obj->mValue & 0xffffffffull);
-  return scope.Close(Int32::NewFromUnsigned(lowBits));
+  args.GetReturnValue().Set(lowBits);
 }
 
-Handle<Value> Int64::ShiftLeft(const Arguments& args) {
-  HandleScope scope;
+void Int64::ShiftLeft(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   if (args.Length() < 1) {
-    ThrowException(Exception::TypeError(String::New("Argument required")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Argument required")));
+    args.GetReturnValue().SetUndefined();
   }
   if (!args[0]->IsNumber()) {
-    ThrowException(Exception::TypeError(String::New("Integer expected")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Integer expected")));
+    args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   uint64_t shiftBy = static_cast<uint64_t>(args[0]->ToNumber()->NumberValue());
   uint64_t value = obj->mValue << shiftBy;
   Local<Value> argv[2] = {
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value >> 32)),
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value & 0xffffffffull))
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value >> 32)),
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value & 0xffffffffull))
   };
-  Local<Object> instance = constructor->NewInstance(2, argv);
-  return scope.Close(instance);
+
+  Local<Function> cons = Local<Function>::New(isolate, constructor);
+  Local<Object> instance = cons->NewInstance(2, argv);
+  args.GetReturnValue().Set(instance);
 }
 
-Handle<Value> Int64::ShiftRight(const Arguments& args) {
-  HandleScope scope;
+void Int64::ShiftRight(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   if (args.Length() < 1) {
-    ThrowException(Exception::TypeError(String::New("Argument required")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Argument required")));
+    args.GetReturnValue().SetUndefined();
   }
   if (!args[0]->IsNumber()) {
-    ThrowException(Exception::TypeError(String::New("Integer expected")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Integer expected")));
+    args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   uint64_t shiftBy = static_cast<uint64_t>(args[0]->ToNumber()->NumberValue());
   uint64_t value = obj->mValue >> shiftBy;
   Local<Value> argv[2] = {
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value >> 32)),
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value & 0xffffffffull))
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value >> 32)),
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value & 0xffffffffull))
   };
-  Local<Object> instance = constructor->NewInstance(2, argv);
-  return scope.Close(instance);
+  Local<Function> cons = Local<Function>::New(isolate, constructor);
+  Local<Object> instance = cons->NewInstance(2, argv);
+  args.GetReturnValue().Set(instance);
 }
 
-Handle<Value> Int64::And(const Arguments& args) {
-  HandleScope scope;
+void Int64::And(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   if (args.Length() < 1) {
-    ThrowException(Exception::TypeError(String::New("Argument required")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Argument required")));
+    args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   uint64_t value;
@@ -291,22 +316,26 @@ Handle<Value> Int64::And(const Arguments& args) {
     Int64* otherObj = ObjectWrap::Unwrap<Int64>(args[0]->ToObject());
     value = obj->mValue & otherObj->mValue;
   } else {
-    ThrowException(Exception::TypeError(String::New("Object or number expected")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Object or number expected")));
+    args.GetReturnValue().SetUndefined();
   }
   Local<Value> argv[2] = {
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value >> 32)),
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value & 0xffffffffull))
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value >> 32)),
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value & 0xffffffffull))
   };
-  Local<Object> instance = constructor->NewInstance(2, argv);
-  return scope.Close(instance);
+  Local<Function> cons = Local<Function>::New(isolate, constructor);
+  Local<Object> instance = cons->NewInstance(2, argv);
+  args.GetReturnValue().Set(instance);
 }
 
-Handle<Value> Int64::Or(const Arguments& args) {
-  HandleScope scope;
+void Int64::Or(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   if (args.Length() < 1) {
-    ThrowException(Exception::TypeError(String::New("Argument required")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Argument required")));
+    args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   uint64_t value;
@@ -316,22 +345,26 @@ Handle<Value> Int64::Or(const Arguments& args) {
     Int64* otherObj = ObjectWrap::Unwrap<Int64>(args[0]->ToObject());
     value = obj->mValue | otherObj->mValue;
   } else {
-    ThrowException(Exception::TypeError(String::New("Object or number expected")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Object or number expected")));
+    args.GetReturnValue().SetUndefined();
   }
   Local<Value> argv[2] = {
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value >> 32)),
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value & 0xffffffffull))
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value >> 32)),
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value & 0xffffffffull))
   };
-  Local<Object> instance = constructor->NewInstance(2, argv);
-  return scope.Close(instance);
+  Local<Function> cons = Local<Function>::New(isolate, constructor);
+  Local<Object> instance = cons->NewInstance(2, argv);
+  args.GetReturnValue().Set(instance);
 }
 
-Handle<Value> Int64::Xor(const Arguments& args) {
-  HandleScope scope;
+void Int64::Xor(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   if (args.Length() < 1) {
-    ThrowException(Exception::TypeError(String::New("Argument required")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Argument required")));
+    args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   uint64_t value;
@@ -341,22 +374,26 @@ Handle<Value> Int64::Xor(const Arguments& args) {
     Int64* otherObj = ObjectWrap::Unwrap<Int64>(args[0]->ToObject());
     value = obj->mValue ^ otherObj->mValue;
   } else {
-    ThrowException(Exception::TypeError(String::New("Object or number expected")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Object or number expected")));
+    args.GetReturnValue().SetUndefined();
   }
   Local<Value> argv[2] = {
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value >> 32)),
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value & 0xffffffffull))
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value >> 32)),
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value & 0xffffffffull))
   };
-  Local<Object> instance = constructor->NewInstance(2, argv);
-  return scope.Close(instance);
+  Local<Function> cons = Local<Function>::New(isolate, constructor);
+  Local<Object> instance = cons->NewInstance(2, argv);
+  args.GetReturnValue().Set(instance);
 }
 
-Handle<Value> Int64::Add(const Arguments& args) {
-  HandleScope scope;
+void Int64::Add(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   if (args.Length() < 1) {
-    ThrowException(Exception::TypeError(String::New("Argument required")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Argument required")));
+    args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   uint64_t value;
@@ -366,22 +403,26 @@ Handle<Value> Int64::Add(const Arguments& args) {
     Int64* otherObj = ObjectWrap::Unwrap<Int64>(args[0]->ToObject());
     value = obj->mValue + otherObj->mValue;
   } else {
-    ThrowException(Exception::TypeError(String::New("Object or number expected")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Object or number expected")));
+    args.GetReturnValue().SetUndefined();
   }
   Local<Value> argv[2] = {
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value >> 32)),
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value & 0xffffffffull))
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value >> 32)),
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value & 0xffffffffull))
   };
-  Local<Object> instance = constructor->NewInstance(2, argv);
-  return scope.Close(instance);
+  Local<Function> cons = Local<Function>::New(isolate, constructor);
+  Local<Object> instance = cons->NewInstance(2, argv);
+  args.GetReturnValue().Set(instance);
 }
 
-Handle<Value> Int64::Sub(const Arguments& args) {
-  HandleScope scope;
+void Int64::Sub(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
   if (args.Length() < 1) {
-    ThrowException(Exception::TypeError(String::New("Argument required")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Argument required")));
+    args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
   uint64_t value;
@@ -391,13 +432,15 @@ Handle<Value> Int64::Sub(const Arguments& args) {
     Int64* otherObj = ObjectWrap::Unwrap<Int64>(args[0]->ToObject());
     value = obj->mValue - otherObj->mValue;
   } else {
-    ThrowException(Exception::TypeError(String::New("Object or number expected")));
-    return scope.Close(Undefined());
+    isolate->ThrowException(
+      Exception::TypeError(String::NewFromUtf8(isolate, "Object or number expected")));
+    args.GetReturnValue().SetUndefined();
   }
   Local<Value> argv[2] = {
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value >> 32)),
-    Int32::NewFromUnsigned(static_cast<uint32_t>(value & 0xffffffffull))
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value >> 32)),
+    Int32::NewFromUnsigned(isolate, static_cast<uint32_t>(value & 0xffffffffull))
   };
-  Local<Object> instance = constructor->NewInstance(2, argv);
-  return scope.Close(instance);
+  Local<Function> cons = Local<Function>::New(isolate, constructor);
+  Local<Object> instance = cons->NewInstance(2, argv);
+  args.GetReturnValue().Set(instance);
 }

--- a/src/Int64.cc
+++ b/src/Int64.cc
@@ -309,7 +309,7 @@ void Int64::And(const FunctionCallbackInfo<Value>& args) {
     args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
-  uint64_t value;
+  uint64_t value = 0;
   if (args[0]->IsNumber()) {
     value = obj->mValue & args[0]->IntegerValue();
   } else if (args[0]->IsObject()) {
@@ -338,7 +338,7 @@ void Int64::Or(const FunctionCallbackInfo<Value>& args) {
     args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
-  uint64_t value;
+  uint64_t value = 0;
   if (args[0]->IsNumber()) {
     value = obj->mValue | args[0]->IntegerValue();
   } else if (args[0]->IsObject()) {
@@ -367,7 +367,7 @@ void Int64::Xor(const FunctionCallbackInfo<Value>& args) {
     args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
-  uint64_t value;
+  uint64_t value = 0;
   if (args[0]->IsNumber()) {
     value = obj->mValue ^ args[0]->IntegerValue();
   } else if (args[0]->IsObject()) {
@@ -396,7 +396,7 @@ void Int64::Add(const FunctionCallbackInfo<Value>& args) {
     args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
-  uint64_t value;
+  uint64_t value = 0;
   if (args[0]->IsNumber()) {
     value = obj->mValue + args[0]->IntegerValue();
   } else if (args[0]->IsObject()) {
@@ -425,7 +425,7 @@ void Int64::Sub(const FunctionCallbackInfo<Value>& args) {
     args.GetReturnValue().SetUndefined();
   }
   Int64* obj = ObjectWrap::Unwrap<Int64>(args.This());
-  uint64_t value;
+  uint64_t value = 0;
   if (args[0]->IsNumber()) {
     value = obj->mValue - args[0]->IntegerValue();
   } else if (args[0]->IsObject()) {

--- a/src/Int64.h
+++ b/src/Int64.h
@@ -3,6 +3,7 @@
 
 #include <node.h>
 #include <v8.h>
+#include <node_object_wrap.h>
 
 using namespace node;
 using namespace v8;
@@ -19,23 +20,23 @@ class Int64 : public ObjectWrap {
   ~Int64();
 
   static Persistent<Function> constructor;
-  static Handle<Value> New(const Arguments& args);
-  static Handle<Value> ToNumber(const Arguments& args);
-  static Handle<Value> ValueOf(const Arguments& args);
-  static Handle<Value> ToString(const Arguments& args);
-  static Handle<Value> ToUnsignedDecimalString(const Arguments& args);
-  static Handle<Value> ToSignedDecimalString(const Arguments& args);
-  static Handle<Value> Equals(const Arguments& args);
-  static Handle<Value> Compare(const Arguments& args);
-  static Handle<Value> High32(const Arguments& args);
-  static Handle<Value> Low32(const Arguments& args);
-  static Handle<Value> ShiftLeft(const Arguments& args);
-  static Handle<Value> ShiftRight(const Arguments& args);
-  static Handle<Value> And(const Arguments& args);
-  static Handle<Value> Or(const Arguments& args);
-  static Handle<Value> Xor(const Arguments& args);
-  static Handle<Value> Add(const Arguments& args);
-  static Handle<Value> Sub(const Arguments& args);
+  static void New(const FunctionCallbackInfo<Value>& args);
+  static void ToNumber(const FunctionCallbackInfo<Value>& args);
+  static void ValueOf(const FunctionCallbackInfo<Value>& args);
+  static void ToString(const FunctionCallbackInfo<Value>& args);
+  static void ToUnsignedDecimalString(const FunctionCallbackInfo<Value>& args);
+  static void ToSignedDecimalString(const FunctionCallbackInfo<Value>& args);
+  static void Equals(const FunctionCallbackInfo<Value>& args);
+  static void Compare(const FunctionCallbackInfo<Value>& args);
+  static void High32(const FunctionCallbackInfo<Value>& args);
+  static void Low32(const FunctionCallbackInfo<Value>& args);
+  static void ShiftLeft(const FunctionCallbackInfo<Value>& args);
+  static void ShiftRight(const FunctionCallbackInfo<Value>& args);
+  static void And(const FunctionCallbackInfo<Value>& args);
+  static void Or(const FunctionCallbackInfo<Value>& args);
+  static void Xor(const FunctionCallbackInfo<Value>& args);
+  static void Add(const FunctionCallbackInfo<Value>& args);
+  static void Sub(const FunctionCallbackInfo<Value>& args);
 
   uint64_t mValue;
 };


### PR DESCRIPTION
There have been many breaking C++ API changes since node 0.10.x.

This PR makes node-int64-native compatible with the stable 0.12.x release.

@candu Please review and let me know if you need any further help. This guide:

https://strongloop.com/strongblog/node-js-v0-12-c-apis-breaking/

was quite helpful in porting.

The motivation was to be able to use @jamesbrucepower 's awesome node Avro library (https://github.com/jamesbrucepower/node-avro-io) with node 12, and that lib is dependent on int64-native.