### PR TITLE
Allow running with the debug version of the node binary

### DIFF
--- a/int64.js
+++ b/int64.js
@@ -1,4 +1,3 @@
-var path = require('path');
+var nativeModule = require('bindings')('Int64.node'); 
 
-var modulePath = path.join(__dirname, 'build', 'Release', 'Int64');
-module.exports = require(modulePath).Int64;
+module.exports = nativeModule.Int64;

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "mocha": "1.8.x"
   },
   "license": "MIT",
-  "readmeFilename": "README.md"
+  "readmeFilename": "README.md",
+  "dependencies": {
+    "bindings": "1.2.x"
+  }
 }


### PR DESCRIPTION
When running with a version of node compiled from source using the --debug option, the Int64 module will fail to find it's native module (due to a directory name change).

These changes allow int64 to work with a debug enabled node binary and probably other corner cases supported by the 'bindings' module.