### PR TITLE
Bump nan to enforce 2.4.0 to supress deprecation warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "bindings": "1.2.x",
-    "nan": "^2.0.8"
+    "nan": "^2.4.0"
   }
 }


### PR DESCRIPTION
On Node 6.2.2 + nan version < 2.3.x, I receive deprecation warnings. See the [nan changelog](https://github.com/nodejs/nan/blob/master/CHANGELOG.md#230-apr-27-2016).